### PR TITLE
Add 'appendExtension' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,13 @@ module.exports = function (options) {
 				}
 
 				file.contents = buf;
-				file.path = gutil.replaceExtension(file.path, '.webp');
+
+				if (options.appendExtension) {
+					file.path += '.webp';
+				} else {
+					file.path = gutil.replaceExtension(file.path, '.webp');
+				}
+
 				cb(null, file);
 			});
 	});

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Default: `false`
 
 ##### appendExtension
 
-Type: `boolean`
+Type: `boolean`  
 Default: `false`
 
 If set to `true`, appends `.webp` to the original extension

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,14 @@ Max: `100`
 Type: `boolean`  
 Default: `false`
 
+##### appendExtension
+
+Type: `boolean`
+Default: `false`
+
+If set to `true`, appends `.webp` to the original extension
+(e.g.:`image.jpg => image.jpg.webp`).
+
 
 ## License
 


### PR DESCRIPTION
This option allows the `.webp` extension to be appended to the path instead of replacing the original extension.

Example:

```js
gulp.src('./img/foo.{png,jpg}')
  .pipe(webp({appendExtension: true}))
  .pipe(gulp.dest('.'));
```

Creates two images: `foo.png.webp` and `foo.jpg.webp`.